### PR TITLE
[create_bulk_users] Allow single-line header and overwrite output file

### DIFF
--- a/exam_user_utilities/README.md
+++ b/exam_user_utilities/README.md
@@ -7,22 +7,24 @@ This directory contains codes for generating bulk Linux users, jupyterhub login 
     * Room number
     * Platz
     * Date <br>
-  Note: this list should not contain any header
+  Note: This list may contain a *single-line* header
 
-| Test User 0 | test02s | 012345 | C175 | 0 | 22.03.2019 |
-|-------------|---------|--------|------|---|------------|
-| Test User 1 | test12s | 012345 | C175 | 1 | 22.03.2019 |
-| Test User 2 | test22s | 012345 | C175 | 2 | 22.03.2019 |
-| Test User 3 | test32s | 012345 | C175 | 3 | 22.03.2019 |
+| Name        | FB02UID | Matrikelnummer | Room | Sitting place |  Exam date |
+|-------------|---------|----------------|------|---------------|------------|
+| Test User 0 | test02s |      012345    | C175 |       0       | 22.03.2019 |
+| Test User 1 | test12s |      123456    | C175 |       1       | 22.03.2019 |
+| Test User 2 | test22s |      234567    | C175 |       2       | 22.03.2019 |
+| Test User 3 | test32s |      345678    | C175 |       3       | 22.03.2019 |
 
 * Linux user generation
   * Arguments required
-    * course_name : the abbreviation of the course name e.g. nn for a neural network course. This username prefix helps us to differentiate among courses.
-    * input_list : the list of students registered for the exam and the list should follow the structure as in point one (e.g. exam_complete_list.csv).
-    * output_list : the generated list with the username and password for each student (e.g. exam_complete_list_output.csv).
+    * course_name: the abbreviation of the course name e.g. nn for a neural network course. This username prefix helps us to differentiate among courses.
+    * input_list: the list of students registered for the exam and the list should follow the structure as in point one (e.g. exam_complete_list.csv).
+    * skip_header (0 or 1): whether the input file contains a header line that should be skipped (default 1)
+    * output_list: the generated list with the username and password for each student (e.g. exam_complete_list_output.csv).
   * Start creating bulk linux users
     ```
-    sudo bash create_bulk_users.sh -course_name wus -input_list samples/exam_complete_list.csv -output_list samples/exam_complete_list_output.csv
+    sudo bash create_bulk_users.sh -course_name wus -input_list samples/exam_complete_list.csv -output_list samples/exam_complete_list_output.csv -skip_header 1
     ```
   * Example of the generated list
 
@@ -41,7 +43,7 @@ This directory contains codes for generating bulk Linux users, jupyterhub login 
   * Once the student username has been added to jupyterhub config, we need to verify them. Run the following code to verify them automatically once the jupyterhub is running.
   * Arguments:
     * server: the jupyterhub server e.g. http://localhost:7777
-    * user_list: the list of users generated from automatic user creation 
+    * user_list: the list of users generated from automatic user creation
   ```
   python check_login --server=http://localhost:7777 --user_list=samples/exam_complete_list_output.csv
   ```

--- a/exam_user_utilities/create_bulk_users.sh
+++ b/exam_user_utilities/create_bulk_users.sh
@@ -1,23 +1,28 @@
 #!/bin/bash
 #title           :create_bulk_users.sh
-#description     :This script will generate multi Linux users
-#author		       :Mohammad Wasil
+#description     :This script will generate multiple Linux users from an input CSV file with entries for
+#                :student name, FB02UID, enrollment number, room, sitting place, and exam date
+#                :(one row per student)
+#author          :Mohammad Wasil
+#contributors    :Mohammad Wasil, Alex Mitrevski
 #Copyright 2019, DigiKlausur project, Bonn-Rhein-Sieg University
 #==============================================================================
 
-export COURSE_NAME=""
-export INPUT_LIST=""
-export OUTPUT_LIST=""
+COURSE_NAME=""
+INPUT_LIST=""
+SKIP_INPUT_HEADER=1
+OUTPUT_LIST=""
 
 if [ $# -eq 0 ]
 then
   echo "Usage: sh create_bulk_users.sh"
   echo " "
   echo "options:"
-  echo "-h, --help                show brief help"
-  echo "-course_name              course name information to give a prefex of the username"
-  echo "-input_list               the input file of a complete student list in csv"
-  echo "-output_list              the output file of the generated username and password in csv"
+  echo "-h, --help                      show brief help"
+  echo "-course_name (str)              course name information to give a prefex of the username"
+  echo "-input_list  (str)              the input file of a complete student list in csv"
+  echo "-skip_header (0 or 1)           whether the input file contains a header line that should be skipped (default 1)"
+  echo "-output_list (str)              the output file of the generated username and password in csv"
   exit 0
 fi
 
@@ -27,24 +32,30 @@ while test $# -gt 0; do
       echo "Usage: sh create_bulk_users.sh"
       echo " "
       echo "options:"
-      echo "-h, --help                show brief help"
-      echo "-course_name              course name information to give a prefex of the username"
-      echo "-input_list               the input file of a complete student list in csv"
-      echo "-output_list              the output file of the generated username and password in csv"
+      echo "-h, --help                      show brief help"
+      echo "-course_name                    course name information to give a prefex of the username"
+      echo "-input_list                     the input file of a complete student list in csv"
+      echo "-skip_header (0 or 1)           whether the input file contains a header line that should be skipped (default 1)"
+      echo "-output_list                    the output file of the generated username and password in csv"
       exit 0
       ;;
     -course_name)
-      export COURSE_NAME="$2"
+      COURSE_NAME="$2"
       shift
       shift
       ;;
     -input_list)
-      export INPUT_LIST="$2"
+      INPUT_LIST="$2"
+      shift
+      shift
+      ;;
+    -skip_header)
+      SKIP_INPUT_HEADER=$2
       shift
       shift
       ;;
     -output_list)
-      export OUTPUT_LIST="$2"
+      OUTPUT_LIST="$2"
       shift
       shift
       ;;
@@ -57,6 +68,7 @@ done
 echo "Given arguments"
 echo "Course name: $COURSE_NAME"
 echo "Input list: $INPUT_LIST"
+echo "Skip input header: $SKIP_INPUT_HEADER"
 echo "Output list: $OUTPUT_LIST"
 echo "--------------------------------------------------"
 
@@ -83,48 +95,56 @@ if [ -z "$OUTPUT_LIST" ]
 fi
 
 # Check input_list exists
-if [ -f "$INPUT_LIST" ]; 
+if [ -f "$INPUT_LIST" ];
   then
     echo ""
-  else 
+  else
     echo "$INPUT_LIST does not exist"
     exit 0
 fi
 
-# Write header to the output list
-echo "Name,FB02UID,Username,Password,Matrikel,Raum,Platz,Date" >> $OUTPUT_LIST
+# Write header to the output list (overwrite the file if it already exists)
+echo "Name,FB02UID,Username,Password,Matrikel,Raum,Platz,Date" > $OUTPUT_LIST
 
 #Start generating users
-while IFS=, read -r col1 col2 col3 col4 col5 col6 || [ -n "$col6" ]
-do
-  STUDENT_NAME="$col1"
-  STUDENT_ID="$col2"
-  MATRIKEL="$col3"
-  RAUM="$col4"
-  PLATZ="$col5"
-  DATE="$col6"
-  
-  # Generate username with course_name as a prefix e.g. nn-username2s
-  STUDENT_USERNAME=$(echo "$COURSE_NAME-$STUDENT_ID")
-    
-  # Create user without password
-  adduser $STUDENT_USERNAME --gecos "$STUDENT_USERNAME, RoomNumber, WorkPhone, HomePhone" --disabled-password
-  
-  # Generate random password
-  RAND_PASSWD=$(shuf -i 10000-100000 -n 1)
-  echo "$STUDENT_USERNAME:$RAND_PASSWD" | chpasswd
-  echo "$STUDENT_USERNAME: $RAND_PASSWD"
-  
-  # Restric user to their own home dir only
-  #setfacl --modify user:$STUDENT_USERNAME:0 /home/$STUDENT_USERNAME
-  #echo "Student $STUDENT_USERNAME is given special permission"
-  #getfacl /home/$STUDENT_USERNAME
-  
-  # You can skip this permission setup
-  # by changing default mode in /etc/adduser.conf
-  # DIR_MODE = 0750 
+{
+    if [ $SKIP_INPUT_HEADER = 1 ];
+      then
+        read -r header
+        echo "Skipping header $header"
+    fi
 
-  # Save username and password to csv
-  echo "$STUDENT_NAME, $STUDENT_ID,$STUDENT_USERNAME, $RAND_PASSWD, $MATRIKEL, $RAUM, $PLATZ, $DATE" >> $OUTPUT_LIST
-done < $INPUT_LIST
+    while IFS=, read -r col1 col2 col3 col4 col5 col6 || [ -n "$col6" ]
+    do
+      STUDENT_NAME="$col1"
+      STUDENT_ID="$col2"
+      MATRIKEL="$col3"
+      RAUM="$col4"
+      PLATZ="$col5"
+      DATE="$col6"
+
+      # Generate username with course_name as a prefix e.g. nn-username2s
+      STUDENT_USERNAME=$(echo "$COURSE_NAME-$STUDENT_ID")
+
+      # Create user without password
+      adduser $STUDENT_USERNAME --gecos "$STUDENT_USERNAME, RoomNumber, WorkPhone, HomePhone" --disabled-password
+
+      # Generate random password
+      RAND_PASSWD=$(shuf -i 10000-100000 -n 1)
+      echo "$STUDENT_USERNAME:$RAND_PASSWD" | chpasswd
+      echo "$STUDENT_USERNAME: $RAND_PASSWD"
+
+      # Restrict user to their own home dir only
+      #setfacl --modify user:$STUDENT_USERNAME:0 /home/$STUDENT_USERNAME
+      #echo "Student $STUDENT_USERNAME is given special permission"
+      #getfacl /home/$STUDENT_USERNAME
+
+      # You can skip this permission setup
+      # by changing default mode in /etc/adduser.conf
+      # DIR_MODE = 0750
+
+      # Save username and password to csv
+      echo "$STUDENT_NAME, $STUDENT_ID,$STUDENT_USERNAME, $RAND_PASSWD, $MATRIKEL, $RAUM, $PLATZ, $DATE" >> $OUTPUT_LIST
+    done
+} < $INPUT_LIST
 echo "-----------------Done---------------------"

--- a/exam_user_utilities/samples/exam_complete_list.csv
+++ b/exam_user_utilities/samples/exam_complete_list.csv
@@ -1,3 +1,4 @@
+Name,FB02UID,Matrikel,Raum,Platz,Date
 Test User 0,test02s,012345,C175,0,22.03.2019
 Test User 1,test12s,012345,C175,1,22.03.2019
 Test User 2,test22s,012345,C175,2,22.03.2019


### PR DESCRIPTION
## Summary of changes

This PR modifies the script `exam_user_utilities/create_bulk_users.sh]` so that:
* the input CSV file can have a header line
* the output CSV file is overwritten every time the script is reran

## Detailed description of changes

In a numpy-like fashion, the script now accepts an argument `skip_header`; if the value of this argument is equal to 1, the first line of the input file will be skipped (this is the default behaviour), otherwise no header will be skipped and all file lines will be processed during user creation.

Additionally, in order not to duplicate content in the output file if the script has to be rerun multiple times, the output file is now overwritten on each execution.

## Other comments

The README file has been updated to reflect the changes.

@mhwasil The PR addresses your comment in https://github.com/DigiKlausur/brsu_digital_exam_tools/pull/1